### PR TITLE
refactor: make groupId field backwards compatible

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -55,7 +55,7 @@ export default class Cloud {
   token: string | null;
   api: NetsBloxApi;
 
-  constructor(url, clientId, username, groupId, localize = defaultLocalizer) {
+  constructor(url, clientId, username, localize = defaultLocalizer, groupId=null) {
     this.clientId = clientId;
     this.username = username;
     this.projectId = null;


### PR DESCRIPTION
Moved the groupId parameter to the end of the constructor parameters with explicit default for backwards compatibility.  